### PR TITLE
Use PNG for lossless Photoshop transfers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ py/__pycache__
 __pycache__
 Install_Plugin/__pycache__
 Install_Plugin/plugincode
-data/ps_inputs/
+data/ps_inputs/*
+!data/ps_inputs/.gitkeep
 
 

--- a/Install_Plugin/3e6d64e0/assets/index-B_-tWO9a.js
+++ b/Install_Plugin/3e6d64e0/assets/index-B_-tWO9a.js
@@ -8945,8 +8945,10 @@ const La = (i = { left: 0, top: 0, right: 0, bottom: 0 }) => {
               .slice(2)}.png`,
             { overwrite: !0 },
           );
+        const rDoc = he.activeDocument;
         await Vt.executeAsModal(async () => {
-          await he.activeDocument.saveAs(o, { fileType: "png", asCopy: !0 });
+          await rDoc.saveAs(o, { fileType: "png", asCopy: !0 });
+          he.activeDocument = rDoc;
         });
         const t = await o.read({ format: require("uxp").storage.formats.base64 });
         return await o.delete(), t;

--- a/Install_Plugin/3e6d64e0/assets/index-B_-tWO9a.js
+++ b/Install_Plugin/3e6d64e0/assets/index-B_-tWO9a.js
@@ -8936,9 +8936,10 @@ const La = (i = { left: 0, top: 0, right: 0, bottom: 0 }) => {
       (e = t.bottom - t.top));
     return ((ji = t), { sourceBounds: t });
   },
-    Ea = async (i, e = "png") => {
+    Ea = async (i, e = "PNG") => {
+      e = e.toUpperCase();
       try {
-        if (e === "png")
+        if (e === "PNG")
           try {
             const r = await Ss.getTemporaryFolder(),
               o = await r.createFile(
@@ -8965,8 +8966,7 @@ const La = (i = { left: 0, top: 0, right: 0, bottom: 0 }) => {
             );
           }
         const t = await vr.getPixels(i),
-          s = { imageData: t.imageData, format: e.toUpperCase(), base64: !0 };
-        e === "jpg" && (s.quality = 12);
+          s = { imageData: t.imageData, format: e, base64: !0 };
         const n = await vr.encodeImageData(s);
         return (t.imageData.dispose(), n);
       } catch (t) {
@@ -9037,7 +9037,7 @@ const La = (i = { left: 0, top: 0, right: 0, bottom: 0 }) => {
             colorSpace: "RGB",
             ...(t && { sourceBounds: t }),
           };
-          ((i = await Ea(s, "png")),
+          ((i = await Ea(s, "PNG")),
             (he.activeDocument.activeHistoryState = e),
             ne.info("📸 Mask saved as base64 PNG"));
         }, "Mask Sent to AI"),
@@ -9060,7 +9060,7 @@ const La = (i = { left: 0, top: 0, right: 0, bottom: 0 }) => {
             colorSpace: "RGB",
             ...(i && { sourceBounds: i }),
           },
-          n = await Ea(t);
+          n = await Ea(t, "PNG");
         return (Xt.set(!1), ne.info("📸 Image saved as base64 PNG"), n);
       });
     } catch (i) {

--- a/Install_Plugin/3e6d64e0/assets/index-B_-tWO9a.js
+++ b/Install_Plugin/3e6d64e0/assets/index-B_-tWO9a.js
@@ -8939,11 +8939,12 @@ const La = (i = { left: 0, top: 0, right: 0, bottom: 0 }) => {
     try {
       if (e === "png") {
         const r = await Ss.getTemporaryFolder(),
-          o = await r.createFile("ps_temp.png", { overwrite: !0 });
+          o = await r.createFile(`ps_temp_${Date.now()}.png`, { overwrite: !0 });
         await Vt.executeAsModal(async () => {
-          await he.activeDocument.saveAs(o, { fileType: "png" });
+          await he.activeDocument.saveAs(o, { fileType: "png", asCopy: !0 });
         });
-        return await o.read({ format: require("uxp").storage.formats.base64 });
+        const t = await o.read({ format: require("uxp").storage.formats.base64 });
+        return await o.delete(), t;
       }
       const t = await vr.getPixels(i),
         s = { imageData: t.imageData, format: e.toUpperCase(), base64: !0 };

--- a/Install_Plugin/3e6d64e0/assets/index-B_-tWO9a.js
+++ b/Install_Plugin/3e6d64e0/assets/index-B_-tWO9a.js
@@ -9208,7 +9208,10 @@ function Hp(i, e, t) {
       }
     },
     b = async () => {
-      (ne.info("🖼️ Canvas Changed: "), Ve(Xt, (u = !0), u), v());
+      if (!f) return;
+      ne.info("🖼️ Canvas Changed: ");
+      Ve(Xt, (u = !0), u);
+      v();
     };
   function y() {
     (Ve(Dt, (r = BigInt(Math.round(Math.random() * 1e6)).toString()), r),
@@ -9217,10 +9220,11 @@ function Hp(i, e, t) {
       k());
   }
   const C = async () => {
-    (f && Ve(Xt, (u = !0), u),
-      ne.info("🎭 Mask Changed: "),
-      Ve(is, (d = !0), d),
-      v());
+    if (!f) return;
+    Ve(Xt, (u = !0), u);
+    ne.info("🎭 Mask Changed: ");
+    Ve(is, (d = !0), d);
+    v();
   };
   async function v() {
     await k();

--- a/Install_Plugin/3e6d64e0/assets/index-B_-tWO9a.js
+++ b/Install_Plugin/3e6d64e0/assets/index-B_-tWO9a.js
@@ -8935,33 +8935,43 @@ const La = (i = { left: 0, top: 0, right: 0, bottom: 0 }) => {
       (e = t.bottom - t.top));
     return ((ji = t), { sourceBounds: t });
   },
-  Ea = async (i, e = "png") => {
-    try {
-      if (e === "png") {
-        const r = await Ss.getTemporaryFolder(),
-          o = await r.createFile(
-            `ps_temp_${Date.now()}_${Math.random()
-              .toString(36)
-              .slice(2)}.png`,
-            { overwrite: !0 },
-          );
-        const rDoc = he.activeDocument;
-        await Vt.executeAsModal(async () => {
-          await rDoc.saveAs(o, { fileType: "png", asCopy: !0 });
-          he.activeDocument = rDoc;
-        });
-        const t = await o.read({ format: require("uxp").storage.formats.base64 });
-        return await o.delete(), t;
+    Ea = async (i, e = "png") => {
+      try {
+        if (e === "png")
+          try {
+            const r = await Ss.getTemporaryFolder(),
+              o = await r.createFile(
+                `ps_temp_${Date.now()}_${Math.random()
+                  .toString(36)
+                  .slice(2)}.png`,
+                { overwrite: !0 },
+              ),
+              rDoc = he.activeDocument;
+            await Vt.executeAsModal(async () => {
+              await rDoc.saveAs(o, { fileType: "png", asCopy: !0 }),
+                (he.activeDocument = rDoc);
+            });
+            const t = await o.read({ format: require("uxp").storage.formats.base64 });
+            return await o.delete(), t;
+          } catch (t) {
+            const r = await vr.getPixels(i),
+              s = { imageData: r.imageData, format: "PNG", base64: !0 },
+              n = await vr.encodeImageData(s);
+            return (
+              ne.warn("⚠️ PNG saveAs failed, using encodeImageData"),
+              r.imageData.dispose(),
+              n
+            );
+          }
+        const t = await vr.getPixels(i),
+          s = { imageData: t.imageData, format: e.toUpperCase(), base64: !0 };
+        e === "jpg" && (s.quality = 12);
+        const n = await vr.encodeImageData(s);
+        return (t.imageData.dispose(), n);
+      } catch (t) {
+        throw (ne.error(`❌ Error saving ${e} image:`, t), t);
       }
-      const t = await vr.getPixels(i),
-        s = { imageData: t.imageData, format: e.toUpperCase(), base64: !0 };
-      e === "jpg" && (s.quality = 12);
-      const n = await vr.encodeImageData(s);
-      return (t.imageData.dispose(), n);
-    } catch (t) {
-      throw (ne.error(`❌ Error saving ${e} image:`, t), t);
-    }
-  },
+    },
   Rp = async () => {
     try {
       let i = "";

--- a/Install_Plugin/3e6d64e0/assets/index-B_-tWO9a.js
+++ b/Install_Plugin/3e6d64e0/assets/index-B_-tWO9a.js
@@ -9211,27 +9211,16 @@ function Hp(i, e, t) {
       v());
   };
   async function v() {
-    p && (await k());
+    await k();
   }
   async function k() {
     let w = {};
     c &&
       (Ve(Dt, (r = BigInt(Math.round(Math.random() * 1e6)).toString()), r),
       Ve(Un, (l = !0), l));
-    if (u) {
-      w.canvasBase64 = await xp();
-    }
-    if (d) {
-      w.maskBase64 = await Rp();
-      var D, W;
-      f &&
-        (W = (D = he.activeDocument) == null ? void 0 : D.selection) != null &&
-        W.bounds &&
-        Ve(Xt, (u = !0), u);
-    }
-    if (l) {
-      w.configdata = await A();
-    }
+    w.canvasBase64 = await xp();
+    w.maskBase64 = await Rp();
+    w.configdata = await A();
     (w.queue = !0),
       ne.info("🚀 Sending Queue ~ combinedData:", w),
       await Lp(JSON.stringify(w));

--- a/Install_Plugin/3e6d64e0/assets/index-B_-tWO9a.js
+++ b/Install_Plugin/3e6d64e0/assets/index-B_-tWO9a.js
@@ -3875,7 +3875,7 @@ const Co = Ee("imageMode", "cover"),
   wi = Ee("fixMaskEdge", !0, !0),
   $i = Ee("showNegativeInput", !1),
   Ln = Ee("NoAnim", !1),
-  on = Ee("cropToBounding", !1),
+  on = Ee("renderOnPSChanges", !1),
   Es = Ee("StaticPanel", !0),
   _s = Ee("DontHideController", !0),
   Ci = Ee("ForceResize", !1),
@@ -9244,6 +9244,7 @@ function Hp(i, e, t) {
   async function P() {
     [Dt, Nt, Tn, On].forEach((w) => {
       w.subscribe(async () => {
+        if (!f) return;
         (Un.set(!0), await v());
       });
     });

--- a/Install_Plugin/3e6d64e0/assets/index-B_-tWO9a.js
+++ b/Install_Plugin/3e6d64e0/assets/index-B_-tWO9a.js
@@ -3875,7 +3875,8 @@ const Co = Ee("imageMode", "cover"),
   wi = Ee("fixMaskEdge", !0, !0),
   $i = Ee("showNegativeInput", !1),
   Ln = Ee("NoAnim", !1),
-  on = Ee("renderOnPSChanges", !1),
+  on = Ee("cropToBounding", !1),
+  psRenderStore = Ee("renderOnPSChanges", !1),
   Es = Ee("StaticPanel", !0),
   _s = Ee("DontHideController", !0),
   Ci = Ee("ForceResize", !1),
@@ -9161,14 +9162,15 @@ const Da = async () => {
 };
 function Hp(i, e, t) {
   let n, s, r, o, a, l, u, f, d, c, p;
-  (Y(i, rt, (w) => t(12, (n = w))),
+  psRenderStore.set(!1),
+    Y(i, rt, (w) => t(12, (n = w))),
     Y(i, Nt, (w) => t(13, (s = w))),
     Y(i, Dt, (w) => t(14, (r = w))),
     Y(i, Tn, (w) => t(15, (o = w))),
     Y(i, On, (w) => t(16, (a = w))),
     Y(i, Un, (w) => t(17, (l = w))),
     Y(i, Xt, (w) => t(18, (u = w))),
-    Y(i, on, (w) => t(19, (f = w))),
+    Y(i, psRenderStore, (w) => t(19, (f = w))),
     Y(i, is, (w) => t(20, (d = w))),
     Y(i, Pi, (w) => t(21, (c = w))),
     Y(i, ki, (w) => t(22, (p = w))));
@@ -9712,7 +9714,7 @@ function Jp(i, e, t) {
   }
   const _ = (S) => St(S, u.t("renderOnPSChanges"));
   function b(S) {
-    ((d = S), on.set(d));
+    ((d = S), psRenderStore.set(d));
   }
   const y = (S) => St(S, u.t("cropToSelectionArea"));
   function C(S) {

--- a/Install_Plugin/3e6d64e0/assets/index-B_-tWO9a.js
+++ b/Install_Plugin/3e6d64e0/assets/index-B_-tWO9a.js
@@ -8939,7 +8939,12 @@ const La = (i = { left: 0, top: 0, right: 0, bottom: 0 }) => {
     try {
       if (e === "png") {
         const r = await Ss.getTemporaryFolder(),
-          o = await r.createFile(`ps_temp_${Date.now()}.png`, { overwrite: !0 });
+          o = await r.createFile(
+            `ps_temp_${Date.now()}_${Math.random()
+              .toString(36)
+              .slice(2)}.png`,
+            { overwrite: !0 },
+          );
         await Vt.executeAsModal(async () => {
           await he.activeDocument.saveAs(o, { fileType: "png", asCopy: !0 });
         });
@@ -9213,35 +9218,23 @@ function Hp(i, e, t) {
     c &&
       (Ve(Dt, (r = BigInt(Math.round(Math.random() * 1e6)).toString()), r),
       Ve(Un, (l = !0), l));
-    const x = [];
-    (u &&
-      x.push(
-        xp().then((q) => {
-          w.canvasBase64 = q;
-        }),
-      ),
-      d &&
-        x.push(
-          Rp().then((q) => {
-            var D, W;
-            ((w.maskBase64 = q),
-              f &&
-                (W = (D = he.activeDocument) == null ? void 0 : D.selection) !=
-                  null &&
-                W.bounds &&
-                Ve(Xt, (u = !0), u));
-          }),
-        ),
-      l &&
-        x.push(
-          A().then((q) => {
-            w.configdata = q;
-          }),
-        ),
-      await Promise.all(x),
-      (w.queue = !0),
+    if (u) {
+      w.canvasBase64 = await xp();
+    }
+    if (d) {
+      w.maskBase64 = await Rp();
+      var D, W;
+      f &&
+        (W = (D = he.activeDocument) == null ? void 0 : D.selection) != null &&
+        W.bounds &&
+        Ve(Xt, (u = !0), u);
+    }
+    if (l) {
+      w.configdata = await A();
+    }
+    (w.queue = !0),
       ne.info("🚀 Sending Queue ~ combinedData:", w),
-      await Lp(JSON.stringify(w)));
+      await Lp(JSON.stringify(w));
   }
   async function P() {
     [Dt, Nt, Tn, On].forEach((w) => {

--- a/Install_Plugin/3e6d64e0/assets/index-B_-tWO9a.js
+++ b/Install_Plugin/3e6d64e0/assets/index-B_-tWO9a.js
@@ -8940,12 +8940,9 @@ const La = (i = { left: 0, top: 0, right: 0, bottom: 0 }) => {
   Ea = async (i, e = "png") => {
     try {
       const t = await vr.getPixels(i),
-        n = await vr.encodeImageData({
-          imageData: t.imageData,
-          format: e.toUpperCase(),
-          quality: e.toLowerCase() === "jpg" ? 1 : void 0,
-          base64: !0,
-        });
+        s = { imageData: t.imageData, format: e, base64: !0 };
+      e === "jpg" && (s.quality = 12);
+      const n = await vr.encodeImageData(s);
       return (t.imageData.dispose(), n);
     } catch (t) {
       throw (ne.error(`❌ Error saving ${e} image:`, t), t);

--- a/Install_Plugin/3e6d64e0/assets/index-B_-tWO9a.js
+++ b/Install_Plugin/3e6d64e0/assets/index-B_-tWO9a.js
@@ -8936,16 +8936,7 @@ const La = (i = { left: 0, top: 0, right: 0, bottom: 0 }) => {
     const { newWidth: s, newHeight: r } = Mp(i, e);
     return ((ji = t), { sourceBounds: t, targetSize: { width: s, height: r } });
   },
-  Mp = (i, e) => {
-    const [t, n] = [Qe(bi), Qe(yi)].map((a) => parseInt(a, 10)),
-      s = i / e;
-    let r = Math.min(Math.max(i, n), t),
-      o = r / s;
-    return (
-      o > t ? ((o = t), (r = o * s)) : o < n && ((o = n), (r = o * s)),
-      { newWidth: r, newHeight: o }
-    );
-  },
+  Mp = (i, e) => ({ newWidth: i, newHeight: e }),
   Ea = async (i, e = "png") => {
     try {
       const t = await vr.getPixels(i),
@@ -9025,9 +9016,9 @@ const La = (i = { left: 0, top: 0, right: 0, bottom: 0 }) => {
             colorSpace: "RGB",
             ...(t && { sourceBounds: t }),
           };
-          ((i = await Ea(s, "jpg")),
+          ((i = await Ea(s, "png")),
             (he.activeDocument.activeHistoryState = e),
-            ne.info("📸 Mask saved as base64 JPG"));
+            ne.info("📸 Mask saved as base64 PNG"));
         }, "Mask Sent to AI"),
         is.set(!1),
         i

--- a/Install_Plugin/3e6d64e0/assets/index-B_-tWO9a.js
+++ b/Install_Plugin/3e6d64e0/assets/index-B_-tWO9a.js
@@ -8933,10 +8933,8 @@ const La = (i = { left: 0, top: 0, right: 0, bottom: 0 }) => {
       Number(Qe(Is)) > 0 && (t = La(t)),
       (i = t.right - t.left),
       (e = t.bottom - t.top));
-    const { newWidth: s, newHeight: r } = Mp(i, e);
-    return ((ji = t), { sourceBounds: t, targetSize: { width: s, height: r } });
+    return ((ji = t), { sourceBounds: t });
   },
-  Mp = (i, e) => ({ newWidth: i, newHeight: e }),
   Ea = async (i, e = "png") => {
     try {
       const t = await vr.getPixels(i),
@@ -8954,7 +8952,7 @@ const La = (i = { left: 0, top: 0, right: 0, bottom: 0 }) => {
       return (
         await he.activeDocument.suspendHistory(async () => {
           const e = he.activeDocument.activeHistoryState,
-            { sourceBounds: t, targetSize: n } = await Ia();
+            { sourceBounds: t } = await Ia();
           await Vt.executeAsModal(async () => {
             (await _t(
               [
@@ -9006,7 +9004,6 @@ const La = (i = { left: 0, top: 0, right: 0, bottom: 0 }) => {
           });
           const s = {
             documentID: he.activeDocument.id,
-            targetSize: n,
             componentSize: 8,
             applyAlpha: !0,
             colorProfile: "sRGB IEC61966-2.1",
@@ -9026,11 +9023,10 @@ const La = (i = { left: 0, top: 0, right: 0, bottom: 0 }) => {
   },
   xp = async () => {
     try {
-      const { sourceBounds: i, targetSize: e } = await Ia();
+      const { sourceBounds: i } = await Ia();
       return await Vt.executeAsModal(async () => {
         const t = {
             documentID: he.activeDocument.id,
-            targetSize: e,
             componentSize: 8,
             applyAlpha: !0,
             colorProfile: "sRGB IEC61966-2.1",

--- a/Install_Plugin/3e6d64e0/assets/index-B_-tWO9a.js
+++ b/Install_Plugin/3e6d64e0/assets/index-B_-tWO9a.js
@@ -8937,8 +8937,16 @@ const La = (i = { left: 0, top: 0, right: 0, bottom: 0 }) => {
   },
   Ea = async (i, e = "png") => {
     try {
+      if (e === "png") {
+        const r = await Ss.getTemporaryFolder(),
+          o = await r.createFile("ps_temp.png", { overwrite: !0 });
+        await Vt.executeAsModal(async () => {
+          await he.activeDocument.saveAs(o, { fileType: "png" });
+        });
+        return await o.read({ format: require("uxp").storage.formats.base64 });
+      }
       const t = await vr.getPixels(i),
-        s = { imageData: t.imageData, format: e, base64: !0 };
+        s = { imageData: t.imageData, format: e.toUpperCase(), base64: !0 };
       e === "jpg" && (s.quality = 12);
       const n = await vr.encodeImageData(s);
       return (t.imageData.dispose(), n);

--- a/Install_Plugin/3e6d64e0/assets/index-B_-tWO9a.js
+++ b/Install_Plugin/3e6d64e0/assets/index-B_-tWO9a.js
@@ -8942,8 +8942,8 @@ const La = (i = { left: 0, top: 0, right: 0, bottom: 0 }) => {
       const t = await vr.getPixels(i),
         n = await vr.encodeImageData({
           imageData: t.imageData,
-          format: e,
-          quality: e === "jpg" ? 1 : void 0,
+          format: e.toUpperCase(),
+          quality: e.toLowerCase() === "jpg" ? 1 : void 0,
           base64: !0,
         });
       return (t.imageData.dispose(), n);

--- a/Install_Plugin/3e6d64e0/assets/index-B_-tWO9a.js
+++ b/Install_Plugin/3e6d64e0/assets/index-B_-tWO9a.js
@@ -9217,7 +9217,7 @@ function Hp(i, e, t) {
     (Ve(Dt, (r = BigInt(Math.round(Math.random() * 1e6)).toString()), r),
       Ve(Un, (l = !0), l),
       ne.info("🎲 Random seed: ", r),
-      k());
+      k(!0));
   }
   const C = async () => {
     if (!f) return;
@@ -9229,7 +9229,8 @@ function Hp(i, e, t) {
   async function v() {
     await k();
   }
-  async function k() {
+  async function k(wt = !1) {
+    if (!wt && !f) return;
     let w = {};
     c &&
       (Ve(Dt, (r = BigInt(Math.round(Math.random() * 1e6)).toString()), r),
@@ -9565,7 +9566,7 @@ function Yp(i) {
     })),
     b.$on("mouseenter", i[15]),
     b.$on("click", function () {
-      tt(i[2].SendQueue) && i[2].SendQueue.apply(this, arguments);
+      tt(i[2].SendQueue) && i[2].SendQueue.apply(this, [!0]);
     }),
     b.$on("contextmenu", function () {
       tt(i[2].randomize) && i[2].randomize.apply(this, arguments);
@@ -14420,7 +14421,7 @@ function Um(i) {
       tt(i[1].randomize) && i[1].randomize.apply(this, arguments);
     }),
     y.$on("click", function () {
-      tt(i[1].SendQueue) && i[1].SendQueue.apply(this, arguments);
+      tt(i[1].SendQueue) && i[1].SendQueue.apply(this, [!0]);
     }),
     (v = new Le({
       props: {

--- a/py/Backend.py
+++ b/py/Backend.py
@@ -23,6 +23,7 @@ ps_inputs_directory = os.path.join(
     "data",
     "ps_inputs",
 )
+os.makedirs(ps_inputs_directory, exist_ok=True)
 
 clients = {}
 photoshop_users = []
@@ -68,8 +69,10 @@ async def save_file(data, filename):
                 decoded = buffer.getvalue()
         except Exception as e:
             print(f"# PS: JPEG->PNG conversion error: {e}")
-    with open(os.path.join(ps_inputs_directory, filename), "wb") as file:
+    file_path = os.path.join(ps_inputs_directory, filename)
+    with open(file_path, "wb") as file:
         file.write(decoded)
+    print(f"# PS: wrote {file_path}")
 
 
 async def save_config(data):

--- a/py/Backend.py
+++ b/py/Backend.py
@@ -61,14 +61,13 @@ async def save_file(data, filename):
     if data.startswith("data:"):
         data = data.split(",", 1)[-1]
     decoded = base64.b64decode(data)
-    if decoded[:2] == b"\xff\xd8":
-        try:
-            with Image.open(BytesIO(decoded)) as img:
-                buffer = BytesIO()
-                img.save(buffer, format="PNG")
-                decoded = buffer.getvalue()
-        except Exception as e:
-            print(f"# PS: JPEG->PNG conversion error: {e}")
+    try:
+        with Image.open(BytesIO(decoded)) as img:
+            buffer = BytesIO()
+            img.save(buffer, format="PNG")
+            decoded = buffer.getvalue()
+    except Exception as e:
+        print(f"# PS: PNG re-encode error: {e}")
     file_path = os.path.join(ps_inputs_directory, filename)
     with open(file_path, "wb") as file:
         file.write(decoded)

--- a/py/nodeRemoteConnection.py
+++ b/py/nodeRemoteConnection.py
@@ -39,12 +39,12 @@ class PhotoshopConnections:
             )
 
         self.TmpDir = tempfile.gettempdir().replace("\\", "/")
-        self.ImgDir = f"{self.TmpDir}/temp_image.jpg"
-        self.MaskDir = f"{self.TmpDir}/temp_image_mask.jpg"
+        self.ImgDir = f"{self.TmpDir}/temp_image.png"
+        self.MaskDir = f"{self.TmpDir}/temp_image_mask.png"
 
-        ImgScript = f"""var saveFile = new File("{self.ImgDir}"); var jpegOptions = new JPEGSaveOptions(); jpegOptions.quality = 10; activeDocument.saveAs(saveFile, jpegOptions, true);"""
+        ImgScript = f"""var saveFile = new File("{self.ImgDir}"); var pngOptions = new PNGSaveOptions(); pngOptions.interlaced = false; activeDocument.saveAs(saveFile, pngOptions, true);"""
 
-        Maskscript = f"""try{{var e=app.activeDocument,a=e.selection.bounds,t=e.activeHistoryState,i=e.artLayers.add(),s=new SolidColor,r=e.artLayers.add(),l=new SolidColor,c=new File("{{self.MaskDir}}"),n=new JPEGSaveOptions;function o(){{s.rgb.hexValue="000000",l.rgb.hexValue="FFFFFF",e.activeLayer=r,e.selection.fill(l),e.activeLayer=i,e.selection.selectAll(),e.selection.fill(s),n.quality=1,e.saveAs(c,n,!0),e.activeHistoryState=t}}e.suspendHistory("Mask Applied","main()")}}catch(y){{File("{{self.MaskDir}}").remove()}}"""
+        Maskscript = f"""try{{var e=app.activeDocument,a=e.selection.bounds,t=e.activeHistoryState,i=e.artLayers.add(),s=new SolidColor,r=e.artLayers.add(),l=new SolidColor,c=new File("{self.MaskDir}"),n=new PNGSaveOptions;function o(){{s.rgb.hexValue="000000",l.rgb.hexValue="FFFFFF",e.activeLayer=r,e.selection.fill(l),e.activeLayer=i,e.selection.selectAll(),e.selection.fill(s),e.saveAs(c,n,!0),e.activeHistoryState=t}}e.suspendHistory("Mask Applied","main()")}}catch(y){{File("{self.MaskDir}").remove()}}"""
 
         with PhotoshopConnection(password=password, host=Server, port=port) as ps_conn:
             ps_conn.execute(ImgScript)


### PR DESCRIPTION
## Summary
- Export Photoshop images and masks as PNG for lossless quality
- Send masks from Photoshop plugin as PNG and avoid automatic resizing

## Testing
- `python -m py_compile py/nodeRemoteConnection.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa345b42bc8322bb54e4127ce1b095